### PR TITLE
[BUGFIX] temp. disable usage of cssnano

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,8 +187,6 @@ module.exports = function(exports, config) {
           on('error', err).
           pipe(gulpif(deploy, postcss([autoprefixer()]))).
           on('error', end).
-          pipe(gulpif(deploy && style.minify, postcss([cssnano()]))).
-          on('error', end).
           pipe(gulpif(deploy && style.minify, rename({suffix: '.min'}))).
           on('error', end).
           pipe(gulpif(!deploy, sourcemap.write('.'))).


### PR DESCRIPTION
When using @supports rules inside a @media query,
NanoCSS struggles and kills the outer media query
and results in completely wrong CSS declarations.
This seems to be a bug in NanoCSS Package.

fixes #22